### PR TITLE
reported in case6262

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -41,3 +41,4 @@
   - url: phantomwebapp.io
   - url: raydium.space
   - url: degentrashpandas.cc
+  - url: dappintegrate.app


### PR DESCRIPTION
Malwarebytes blocks the site as spyware

From Google results on Reddit DMs from scammers as mentioned in the case6262 too:

![z5ux26hhfdp71](https://user-images.githubusercontent.com/93533411/142194112-8ba656c8-2d54-45bd-a3b1-ce4e02e29d14.jpg)

