### PR TITLE
Prevent the blocklist from being bundled in browser builds

### DIFF
--- a/browser.d.ts
+++ b/browser.d.ts
@@ -1,0 +1,1 @@
+export * from "./index";

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,30 @@
+let warned = false;
+function warn(detailsMessage) {
+  if (warned) {
+    return;
+  }
+  console.warn(
+    "@phantom-labs/blocklist is not intended for use in-browser.",
+    detailsMessage
+  );
+  warned = true;
+}
+
+const getVersion = () => {
+  warn("`getVersion()` has returned a fake version");
+  return "0.0.0";
+};
+
+const EMPTY_BLOCKLIST = {
+  contentHash: "",
+  blocklist: [],
+  fuzzylist: [],
+  whitelist: [],
+};
+const getBlocklist = () => {
+  warn("`getBlocklist()` has returned an empty blocklist");
+  return EMPTY_BLOCKLIST;
+};
+
+exports.getVersion = getVersion;
+exports.getBlocklist = getBlocklist;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@phantom-labs/blocklist",
   "version": "0.13.0",
+  "browser": "browser.js",
   "main": "index.js",
   "types": "index.d.ts",
   "repository": "git@github.com:phantom-labs/blocklist.git",


### PR DESCRIPTION
Presently, the blocklist is 4.3K gzipped, but surely slated to grow much, much larger. Anyone who imports this into a _client side_ app will pass the ever-growing cost of those bytes onto their users, which will slow down dApp startup over time.

In this PR, we deliver an empty blocklist and a console warning to anyone who bundles and uses `@phantom-labs/blocklist` in a browser-destined bundle.

<img width="750" alt="image" src="https://user-images.githubusercontent.com/13243/162027679-4581f686-0a42-4864-91e7-7a683511256d.png">
