### PR TITLE
Disable vscode format on save for yaml in this repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[yaml]": {
+    "editor.formatOnSave": false
+  }
+}


### PR DESCRIPTION
When I was adding to this repo VSCode kept wanting to change the format of the yaml files. This PR adds a `.vscode/settings.json` file that disables format-on-save only in this repo and only for yaml files, for anyone who opens the repo using VSCode. 