### PR TITLE
Update nft-blocklist.yaml

### DIFF
--- a/nft-blocklist.yaml
+++ b/nft-blocklist.yaml
@@ -65,3 +65,12 @@
   - mint: CHUzskHjG8o7dU9yNBcZQ3PRigNwQ5pm8hLpKXTB9bmd
   - mint: FuP1ZW86dDhVfTEnfFtuXCsQ4sciRvs3QC4q21ZdPUcB
   - mint: 5hVjPnabypzuPYWVt1Ax5pFuWra5usA9jv3FSLYWBhZq 
+  - mint: 9YjVqiThZoYxpjFwbvWQVdL4CoU8stNKru8LYqmeZNiE
+  - mint: 2dACSQTvp6KPeHbqTrGc4ZKhy6ktoUKe8QJyWCd7dPys
+  - mint: CbDxSf747LfaPXayGxPm6847QEmzwAwTQ7VfRPGgsPYK
+  - mint: 8yaPpgm9vE7CMQ7yEgs8MUYpLZ5CJsei2TvVAEqpyJcn
+  - mint: 2WG4YWjh4cTXWoWfhyq8EMhMgNjCwBNFd3Rjqj3wDn8N
+  - mint: 65HT2kftASQGS2hRJ4UggygqLDy9x3jSEQsLXhHTz6Pw
+  - mint: BkQzTm4JxrQNWVsnh3b1yt7LzFSH7KQCAuYfHGh5XbPi
+  - mint: HEfwh9WmbsUSr4ZEornqrdfEoAu8LJ8sYvWBPd2orjoC
+  - mint: FeVavymeg7R43MXz31EsMFNcvRcaHQ1ouQpUzDVjWnSz


### PR DESCRIPTION
added zerium / terium scam and soldrop (official solana scam) tokens