### PR TITLE
Added fake yawww site to blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -1591,6 +1591,7 @@
   - url: justape.live-mint.io
   - url: phantomsupport.vercel.app
   - url: yawww.io-trade.org
+  - url: yawww.io-trade.in
   - url: solpokemon.click 
   - url: solscan.tech
   - url: revokeaccess.com


### PR DESCRIPTION
Some people in the Solana ecosystem got scammed because they used a fake yawww.io website.