### PR TITLE
[feat] Add new interface for clients for multichain

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,5 +5,15 @@ export interface PhantomBlocklist {
   whitelist: string[]
 };
 
+export interface PhantomBlocklistMultichain {
+  contentHash: string,
+  blocklist: string[],
+  fuzzylist: string[],
+  whitelist: string[],
+  ethBlocklist: string[]
+};
+
+
 export declare function getVersion(): string;
 export declare function getBlocklist(): PhantomBlocklist;
+export declare function getBlocklistMultichain(): PhantomBlocklistMultichain;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phantom-labs/blocklist",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "main": "index.js",
   "types": "index.d.ts",
   "repository": "git@github.com:phantom-labs/blocklist.git",


### PR DESCRIPTION
* This PR adds a new interface that includes a field for the Ethereum blocklist.
* Bumping the version to ensure backwards compatibility for clients that may only be using the blocklist for Solana