### PR TITLE
[feat] unbump version, add getter for multichain blocklist

### DIFF
--- a/build.js
+++ b/build.js
@@ -12,7 +12,9 @@ const fuzzylist = yaml.load(fs.readFileSync('./fuzzylist.yaml', 'utf8'));
 // Multichain blocklist concatenates each blockchains blocklist
 const solBlocklistArray = solBlocklist.map((item) => { return item.url });
 const ethBlocklistArray = ethBlocklist.map((item) => { return item.url });
-const multichainBlocklistArray = ethBlocklistArray.concat(solBlocklistArray);
+// Important: Solana list must be at the head because of the way the cursor works
+// TODO: This is jank, we should fix this
+const multichainBlocklistArray = solBlocklistArray.concat(ethBlocklistArray);
 
 // Construct output files for solana only
 const data = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,15 +5,6 @@ export interface PhantomBlocklist {
   whitelist: string[]
 };
 
-export interface PhantomBlocklistMultichain {
-  contentHash: string,
-  blocklist: string[],
-  fuzzylist: string[],
-  whitelist: string[],
-  ethBlocklist: string[]
-};
-
-
 export declare function getVersion(): string;
 export declare function getBlocklist(): PhantomBlocklist;
-export declare function getBlocklistMultichain(): PhantomBlocklistMultichain;
+export declare function getBlocklistMultichain(): PhantomBlocklist;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const { version } = require("./package.json");
 const blocklist = require("./blocklist.json");
+const blocklistMultichain = require("./multichain/blocklist.json");
 
 const getVersion = () => {
   return version;
@@ -9,5 +10,10 @@ const getBlocklist = () => {
   return blocklist;
 }
 
+const getBlocklistMultichain = () => {
+  return blocklistMultichain;
+}
+
 exports.getVersion = getVersion;
 exports.getBlocklist = getBlocklist;
+exports.getBlocklistMultichain = getBlocklistMultichain;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phantom-labs/blocklist",
-  "version": "0.14.0",
+  "version": "0.13.0",
   "main": "index.js",
   "types": "index.d.ts",
   "repository": "git@github.com:phantom-labs/blocklist.git",


### PR DESCRIPTION
* Bump version back to original 0.13.0 in order to maintain proper cursor/ caching functionality
* Add export function for getting multichain blocklist