### PR TITLE
Block memoriamedalion.space (TomorrowlandNFT Scam)

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2132,3 +2132,4 @@
   - url: lotusgang.space
   - url: christmasbox.info
   - url: tomorrowlandnft.space
+  - url: memoriamedalion.space


### PR DESCRIPTION
Hi,

My previous request to block this domain was denied because the maintainer could not access the site, however this domain is still active (it is the redirect target of tomorrowlandnft.space). They may be using some referrer trickery but it is 100% up.

See attached screenshot (date/time stamped)
URL: https://www.memoriamedalion.space/

![Screenshot 2022-12-28 202042](https://user-images.githubusercontent.com/25624489/209797230-cadea514-c05b-4418-b86f-73a31d053040.png)
