### PR TITLE
Add magiceden phishing site + NFT

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2145,3 +2145,4 @@
   - url: orcadao.net
   - url: phantom-security.live
   - url: hypeprimates.netlify
+  - url: mysterybox-magiceden.netlify.app

--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2145,4 +2145,3 @@
   - url: orcadao.net
   - url: phantom-security.live
   - url: hypeprimates.netlify
-  - url: mysterybox-magiceden.netlify.app

--- a/nft-blocklist.yaml
+++ b/nft-blocklist.yaml
@@ -1338,3 +1338,4 @@
   - mint: GTX2AgLAU1rvsq4DheBCrqAfdvv4rh4zSfYsA7LAzswA
   - mint: 9p6pm8YvPjkNPfSGaL1AbZUAuXctsyKD7AtwuWCzwpj4
   - mint: 8S4L6PDYKBKhp8jtJf6sxMJM9vsAGDALDoNfcXRvoWzh
+  - mint: Cx7BUjZ5SkUYataixjzyBeuKDHAYvJ3U8RmyrE7u4QfQ


### PR DESCRIPTION
Received this token: https://solscan.io/token/Cx7BUjZ5SkUYataixjzyBeuKDHAYvJ3U8RmyrE7u4QfQ 

PR adds its mint and website to blocklists

Note that it's a fungible asset, does adding the mint to nft-blocklist still work? 