### PR TITLE
Remove legitimate site babylon.game from blocklist

### DIFF
--- a/eth-blocklist.yaml
+++ b/eth-blocklist.yaml
@@ -53,7 +53,6 @@
   - url: chronos.ltd
   - url: c7nft.com
   - url: lucky-drop.site
-  - url: babylon.game
   - url: pqnfts.com
   - url: apeabu.xyz
   - url: animus-rtfkt.net


### PR DESCRIPTION
`babylon.game` was added to the Phantom blocklist as part of a sync with MetaMask in [this commit](https://github.com/phantom-labs/blocklist/commit/e2a9731fa786253f207bfae40eb9744997aa1715).

However, `babylon.game` was added to MetaMask's blocklist in error and was removed in [this pull request](https://github.com/MetaMask/eth-phishing-detect/pull/11556).

The contributor who added `babylon.game` to the MetaMask blocklist, [blocksecscamreport](https://github.com/blocksecscamreport), wrote ["We have confirmed that it is a legitimate site"](https://github.com/MetaMask/eth-phishing-detect/pull/11556#issuecomment-1430617354) the pull request that removed `babylon.game` from the MetaMask block list.

In light of this, `babylon.game` should be removed from Phantom's block list as well.

Thank you!