### PR TITLE
added flarex.io domain to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,4 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: "*.flarex.io"


### PR DESCRIPTION
flarex.io is my domain, and I am developing an edge computing Web3 application on Solana. Please allow my domain to be added to the whitelist. Thank you.