### PR TITLE
Add ewon.site to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,4 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: ewon.site


### PR DESCRIPTION
I admin the website `ewon.site` it is Known-Good and used at the CTO site for the crypto coin $EWON. 

Please ensure the white list is updated to include `ewon.site` Thank you