### PR TITLE
feat: add bitget wallet official site into whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,5 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: "*.bitget.site"
+

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,4 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: nftplus.io


### PR DESCRIPTION
Hi Phantom team,

We are the Bitget Wallet team. We found that our official website has been tagged as a malicious website. This is our official site, and we would like to request its removal from the blocklist.

Please feel free to contact us if you have any further questions.

Thank you!

Bitget Wallet Team