### PR TITLE
add nftplus.io to WL

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -30,3 +30,4 @@
   - url: "*.tistory.com"
   - url: "*.surge.sh"
   - url: revoke.cash
+  - url: nftplus.io


### PR DESCRIPTION
I admin the website nftplus.io.
we face phantom browser alerts our site is scam.

Please ensure the white list is updated to include nftplus.io Thank you