### PR TITLE
Request: add firebaseapp.com domain to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: "*.firebaseapp.com"


### PR DESCRIPTION
Hello Phantom team,

The purpose of this pr is to add `*.firebaseapp.com` to the whitelist as per the [README]. (https://github.com/phantom/blocklist?tab=readme-ov-file#adding-subdomains)

[VirusTotal report for firebaseapp.com](https://www.virustotal.com/gui/url/a546bd9b9b7ceac97fd7c3a69f6b3cc5441a9c3686ee91f3c4ae9aa425862b74)


