### PR TITLE
Whitelist Romeprotocol servers

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: "*.romeprotocol.xyz"


### PR DESCRIPTION
We are building a Solana-based EVM that enables Ethereum-like transactions to be executed seamlessly on the Solana network. As part of our functionality, our Swap UI allows users to convert SOL to Wrapped SOL (rSOL), which can then be used to pay transaction fees and run transactions within the ecosystem.

To ensure smooth integration and improve user experience, we would like to request that our domains be whitelisted in Phantom Wallet. More technical and project details can be found in our documentation here: https://docs.rome.builders/
