### PR TITLE
add natlon.fun to blocklist (phising)

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2319,3 +2319,4 @@
   - url: pumpp-fun.pages.dev
   - url: phantom-restorewalletteamdesk.webflow.io
   - url: dextoolwallets.on.fleek.co
+  - url: natlon.fun


### PR DESCRIPTION



Phising [natlon.fun](https://natlon.fun/) (with L instead of i)
![image](https://github.com/user-attachments/assets/19992706-e9ab-4293-b21b-0ff1eab5227c)


Original Site [nation.fun](https://nation.fun/trenches)
![image](https://github.com/user-attachments/assets/b6d4f56c-2f8b-4931-862e-96c3631c1b49)
