### PR TITLE
Add universal-OS domains to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,6 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: uos.agency
+  - url: uos.earth
+  - url: uos.finance


### PR DESCRIPTION
uos.agency is being incorrectly flagged as a phishing website. 

To prevent this, uos.agency, along with uos.earth and uos.finance (other domains controlled by Universal-OS) has been added to the whitelist as a precaution.