### PR TITLE
Update whitelist.yaml - Whitelist eosauthority and subdomains

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,5 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: eosauthority.com
+  - url: "*.eosauthority.com"


### PR DESCRIPTION
Kindly note that https://eosauthority.com/ is an EOS founding block producer.

Another malicious entity has requested to block our EOS explorer https://eosauthority.com/ and we in the process of getting these whitelisted.

The website and explorer has been serving as the only reliable block explorer for eos and various blockchains on eosio like wax and telos.

Please see https://wax.eosauthority.com/  http://telos.eosauthority.com/

Our twitter https://x.com/EOSauthority and you can see our website being used for several years and linked from sites like coin telegraph https://cointelegraph.com/news/blockone-joins-eos-elections-as-one-entity-allegedly-has-37-control (See "EOS Authority")

I hope this gets resolved asap as visitors with Phantom get a warning as attached
<img width="891" alt="image" src="https://github.com/user-attachments/assets/4cd55590-85e5-405e-a90a-fc9729cf5efe" />
