### PR TITLE
Whitelist request: *.tp.xyz

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: "*.tp.xyz"


### PR DESCRIPTION
tp.xyz is one of TokenPocket's official site.  

You can see https://x.com/tokenpocket_tp for details.