### PR TITLE
Whitelist cointelegraph.com

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,5 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+
+  - url: "*.cointelegraph.com"


### PR DESCRIPTION
The issue appears to have been resolved on Cointelegraph’s end. I tested the site in a different browser, and the pop-up no longer appears.

https://x.com/Cointelegraph/status/1937077253373866301