### PR TITLE
Add gmonad.cc to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: gmonad.cc


### PR DESCRIPTION
gmonad.cc is the official website of the Chinese community for the Monad blockchain, a high-performance, EVM-compatible Layer 1 protocol. The site is used to share technical resources, community updates, event information, and developer onboarding materials related to the Monad ecosystem.

Since the site is currently under active development, some debugging or deployment operations might have unintentionally triggered a false positive. We kindly ask for the block to be removed. Thank you for your understanding and support.

GitHub repo: https://github.com/monad-cn/gmonad.cc