### PR TITLE
Whitelist presale.guaso.online and subdomains

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,5 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: presale.guaso.online
+  - url: "*.presale.guaso.online"


### PR DESCRIPTION
This PR whitelists our presale domain and its subdomains for Guaso Coin (the utility token for our new Mesh Network).

**Socials for verification:**
- GitHub: Gbe-Network
- Twitter: @NetworkGbe
- Instagram: networkgbe

Project repo: https://github.com/Gbe-Network/Mesh-Network-Presale
