### PR TITLE
added delphilabs.io to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: delphilabs.io


### PR DESCRIPTION
Our company website https://delphilabs.io/ is blocked by phantom. This PR adds the domain to the whitelist so it will no longer be blocked.

I am @lukedelphi on X and can also email you from my luke@delphilabs.io address.