### PR TITLE
Update whitelist.yaml

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: pumpfarmer.pro


### PR DESCRIPTION
Either the fuzzylist or some other pattern blocked our site, reported by users. Metamask already removed the blocked but it seems we need to add a whitelist entry here manually. We don't even use any wallet-connect so the block is obviously not correct and we got added by some trolls.