### PR TITLE
whitelist add 2ha.fun

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: "*.2ha.fun"


### PR DESCRIPTION
Dear Phantom Team,

We are the development team for 2ha.fun, a new meme coin launchpad built upon the open-source [https://github.com/elizaOS/auto.funauto.fun](https://github.com/elizaOS/auto.fun) project, ensuring that our smart contracts and core functionalities are based on a publicly audited and community-vetted foundation. The domain 2ha.fun is the sole, official portal for our project.

As we approach our public launch, our top priority is ensuring a secure and seamless experience for our users. We are writing to you proactively to request a security review of our website and application. We want to ensure that our community can connect their Phantom wallets with confidence, free from any warnings that might incorrectly flag our site as malicious.

We are available to provide any information you might need, including technical details about our implementation of the auto.fun project. You can reach us at contact@2ha.fun.

Thank you for your time and your commitment to securing the Solana network.

Sincerely,

The 2ha.fun Team