### PR TITLE
Whitelist *.healthn.ai

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: "*.healthn.ai"


### PR DESCRIPTION
Hello Phantom Team,

I am the developer of a legitimate dApp using the domain `*.healthn.ai`. My domain appears to have been mistakenly added to your blocklist, which is causing users to receive a warning and be unable to connect their wallets.

Our project is a legitimate dApp, not a scam or phishing site. The block is likely a false positive. We are committed to providing a secure and valuable service to our users.

Please review our domain and consider removing it from the blocklist. We are ready to provide any further information or evidence you may need to verify our legitimacy.

Thank you for your attention to this matter.

Best regards,