### PR TITLE
whitelist coinshift.global

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: coinshift.global


### PR DESCRIPTION
Hello Phantom Team,

I am the Lead developer behind Coinshift, operating under the domain coinshift.global.
It appears that our domain may have been mistakenly added to your blocklist, which is preventing users from connecting their wallets and displaying warning messages.

Since 2021, Coinshift is a treasury management solution for B2B businesses like Aave, UMA, Gitcoin, Zapper etc.
We are backed by Tiger Global and Sequoia India.

Please check more about Coinshift here:
[https://x.com/0xCoinshift](https://x.com/0xCoinshift)
[https://cryptorank.io/ico/coinshift#funding-rounds](https://cryptorank.io/ico/coinshift#funding-rounds)
