### PR TITLE
whitelist openra.net

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: openra.net


### PR DESCRIPTION
No idea why openra.net is blocked. AFAIK the project has been established for a long time.