### PR TITLE
Added Klaytn and Kaia to Whitelist domain list 

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,5 +31,8 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+
   - url: "*.klaytn.foundation"
+  - url: "klaytn.foundation"
   - url: "*.kaia.io"
+  - url: "kaia.io"

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,7 +31,6 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
-
   - url: "*.klaytn.foundation"
   - url: "klaytn.foundation"
   - url: "*.kaia.io"

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,5 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: "*.klaytn.foundation"
+  - url: "*.kaia.io"


### PR DESCRIPTION
Hi Team,

we recently observed Klaytn Foundation urls are blocked.
So added klaytn and kaia blockchain websites to the whitelist file. We own both of this domains. they are legit and we are still maintaining them.

Please let us know if you have further questions and also can confirm by dropping a message to contact@kaia.io as well if you would like to communicate more.

Thank you very much.