### PR TITLE
Whitelist dripshop.live

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: "*.dripshop.live"


### PR DESCRIPTION
Hello Phantom Team,

I’m one of the developers at Dripshop, operating under the domain dripshop.live.
It appears that our domain has been mistakenly added to your blocklist, which is currently preventing users from connecting their wallets and triggering security warnings.

Dripshop is a live shopping platform that merges e-commerce with real-time entertainment, enabling creators and communities to connect through interactive live sales. Since our launch, we’ve built a trusted ecosystem of verified creators and shoppers, with a strong focus on safety, transparency, and compliance.

We believe this blocklisting may be an error and kindly request your assistance in reviewing and removing dripshop.live from the list. You can learn more about our platform and ongoing initiatives on our website and recent public communications:
Official X (Twitter) Post: [https://x.com/dripshop_live/status/1983194931377176739](https://x.com/dripshop_live/status/1983194931377176739)
Website: [https://dripshop.live](https://dripshop.live)

Thank you for your time and assistance. Please let us know if any further information or verification is needed to expedite this review.


Current issue is our app shown as malicious to our customers:
<img width="738" height="1278" alt="Screenshot 2025-12-11 at 5 15 49 PM" src="https://github.com/user-attachments/assets/2fc5dfd9-bb56-47a3-ac5b-33a9fc0102d7" />
