### PR TITLE
Add itsstg.space domain to the whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: "*.itsstg.space"


### PR DESCRIPTION
I am the administrator of the website itsstg.space.
Recently, we noticed that Phantom displays a warning indicating that our domain may be associated with scam or malicious activity.

We would like to kindly request a review of our domain and an update to the whitelist to include itsstg.space, as this warning negatively impacts our users.

Thank you very much for your time and assistance.