### PR TITLE
add *.bingx.pro *.bingxzone.com to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,5 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: "*.bingx.pro"
+  - url: "*.bingxzone.com"

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -32,4 +32,6 @@
   - url: revoke.cash
   - url: nftplus.io
   - url: "*.bingx.pro"
+  - url: "*.bingx.io"
   - url: "*.bingxzone.com"
+  - url: "*.bingxtech.com"


### PR DESCRIPTION
I admin the website bingx.pro and bingxzone.com.
Both of these site are backup domain for some counrty.
we face phantom browser alerts our site is scam.

Please ensure the white list is updated to include those two domains. 
Thank you

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the allowlist to recognize additional domain patterns, improving compatibility with extended service infrastructure while maintaining all existing allowlisted entries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phantom/blocklist/pull/1745)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->