### PR TITLE
Add activator-kmspico.com to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: activator-kmspico.com


### PR DESCRIPTION
**Domain:** activator-kmspico.com

### Description
It recently came to my attention, that for unknown reasons my website got blacklisted by Phantom browser extension.
Visitors contacted us with complains they have issues reaching my content.

### Website content

- No connection with cryptocurrency.
- Educational purpose website. It does not contain any download links or redirects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain whitelist to include activator-kmspico.com and nftplus.io.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->