### PR TITLE
Update blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2319,3 +2319,4 @@
   - url: pumpp-fun.pages.dev
   - url: phantom-restorewalletteamdesk.webflow.io
   - url: dextoolwallets.on.fleek.co
+  - url: bloomsniper.fun


### PR DESCRIPTION
Add bookmark draining site bloomsniper.fun, the site contains a button with javascript in it, that when you drag it to your bookmarks and click it on axiom it automatically drains your whole balance and if u have phantom connected to the axiom then also your phantom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added bloomsniper.fun to the domain blocklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->