### PR TITLE
Update blocklist.yaml

### DIFF
--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2320,3 +2320,4 @@
   - url: phantom-restorewalletteamdesk.webflow.io
   - url: dextoolwallets.on.fleek.co
   - url: vortexvolume.pro
+  - url: bloom-sniper.net

--- a/blocklist.yaml
+++ b/blocklist.yaml
@@ -2319,3 +2319,4 @@
   - url: pumpp-fun.pages.dev
   - url: phantom-restorewalletteamdesk.webflow.io
   - url: dextoolwallets.on.fleek.co
+  - url: vortexvolume.pro


### PR DESCRIPTION
Add bookmark draining site vortexvolume.pro, people are being tricked into bookmarking a button (javascript) and clicking it on the legit vortexdeployer website, and get their entire balance drained


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added two domains to the blocklist: vortexvolume.pro and bloom-sniper.net.
  * These entries were appended to the blocklist; no other user-facing changes or updates to public declarations were included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->