### PR TITLE
Whitelist monero-web.com — false positive

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: monero-web.com


### PR DESCRIPTION
Website URL: monero-web.com

Reason for Request: > This is a false positive block. monero-web.com is a non-custodial, open-source web interface for the Monero (XMR) blockchain. It does not store user private keys or transmit sensitive data to any server.

Technical Details:

Client-Side: All transaction signing and key generation happen locally in the user's browser.

Transparency: The site is fully auditable. Source code is hosted here: https://github.com/Medtabka/monero-web

Community Trust: Project announced and discussed with the Monero community here: https://www.reddit.com/r/Monero/comments/1skgqc4/monerowebcom_opensource_noncustodial_monero/

It appears the domain was automatically flagged due to containing the keyword "monero." Please review the source code and whitelist this domain. Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `monero-web.com` to the whitelist.
  * Corrected whitelist file formatting and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->