### PR TITLE
chore(ci): pin external GitHub Actions to commit SHAs (SEC-9867)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Use Node.js 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 16
           cache: "yarn"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: "18"
           cache: yarn
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@b8130d9ab958b325bbde9786d62f2c97a9885a0e # v3
       - name: Install dependencies
         run: yarn install
       - name: Build
@@ -40,7 +40,7 @@ jobs:
           mv multichain/blocklist-full.json ./out/multichain/
           mv blocklist-full.json ./out/
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@84bb4cd4b733d5c320c9c9cfbc354937524f4d64 # v1
         with:
           path: ./out
 
@@ -54,4 +54,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@f27bcc15848fdcdcc02f01754eb838e44bcf389b # v1


### PR DESCRIPTION
## Summary

- Pins all unpinned external `uses:` refs in `.github/workflows/pages.yml` and `.github/workflows/ci.yml` to full 40-character commit SHAs.
- No runtime / application / config changes — this PR is scoped to SHA pinning so the org can enable the pin-to-SHA check.

## Why

Part of the Supply Chain Security rollout tracked in [SEC-9867](https://linear.app/phantom-labs/issue/SEC-9867) (follow-up to the org-wide audit in [SEC-6683](https://linear.app/phantom-labs/issue/SEC-6683)). Pinning to commit SHAs prevents upstream tag mutation from silently changing what runs in CI.

## Actions pinned

| Ref | SHA |
|---|---|
| `actions/checkout@v2` | `ee0669bd1cc54295c223e0bb666b733df41de1c5` |
| `actions/checkout@v3` | `f43a0e5ff2bd294095638e18286ca9a3d1956744` |
| `actions/setup-node@v3` | `3235b876344d2a9aa001b8d1453c930bba69e610` |
| `actions/configure-pages@v3` | `b8130d9ab958b325bbde9786d62f2c97a9885a0e` |
| `actions/upload-pages-artifact@v1` | `84bb4cd4b733d5c320c9c9cfbc354937524f4d64` |
| `actions/deploy-pages@v1` | `f27bcc15848fdcdcc02f01754eb838e44bcf389b` |

## Test plan

- [ ] CI workflows run green on this PR (inspect Actions tab once opened)
- [ ] Pre-existing failures, if any, are noted here and do not block

Refs: SEC-6683, SEC-9867