### PR TITLE
Whitelist csgofast.store - official marketing mirror of csgofast.com (false positive)

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: csgofast.store


### PR DESCRIPTION
Hi Phantom team,

Submitting this as a PR since `phantom/blocklist` has Issues disabled and the README points to PRs as the submission channel for both blocklist and whitelist changes.

**csgofast.store** is an **official marketing mirror** of [csgofast.com](https://csgofast.com), a CS2/CSGO skin platform live since 2015. Users have reported that Phantom flags `csgofast.store` as malicious.

I could not find `csgofast.store` in any of the YAML files on `master` or in commit history, so the warning seen in-wallet may be coming from a downstream provider Phantom integrates with (Blowfish? GoPlus?). Filing here regardless — this repo is the public surface, and a `whitelist.yaml` entry is the right preventive signal either way. Happy to refile elsewhere if you point me at the right channel.

### Why this is a false positive

The brand-on-different-TLD pattern is exactly what makes legitimate marketing mirrors look indistinguishable from typosquatting clones to automated detectors. We understand the heuristic, we just want to clear this one specific case:

- Same product, same operator, same brand as csgofast.com.
- No seed-phrase prompts, no fake mint pages, no token-approval traps.
- Crypto interactions are limited to standard deposit / P2P-withdrawal flows via WalletConnect / EIP-1193.

### How to verify (any of these works)

1. Email **support@csgofast.com** — we will perform any proof-of-control you ask for (DNS TXT, HTTP challenge on either domain, signed message).
2. Visual / functional comparison — both domains serve the same SPA, same login domain pattern, same provably-fair verification page.
3. We can publish `csgofast.com/.well-known/mirrors.json` listing every marketing mirror if you want a machine-readable signal for future reviews — happy to coordinate on the exact format.

### Asks

1. Please merge this whitelist entry, or, if the in-wallet warning comes from an upstream feed Phantom integrates with, point us at the right contact and I will refile there.
2. **What is the recommended path for a legitimate operator with multiple marketing mirrors to avoid these false positives in the future?** PR each mirror to `whitelist.yaml` proactively? Publish a `/.well-known/` manifest? Use `rel=canonical` or JSON-LD `sameAs` from the mirrors to the primary domain?

Thanks for the work — automated phishing detection is necessary, we do not want to make your job harder, just get our domain off the wrong list.

— csgofast.com team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the service domain whitelist to include additional third-party providers, enabling broader service integration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->