### PR TITLE
chore: add campus-party.org to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,4 +31,4 @@
 - url: "*.surge.sh"
 - url: revoke.cash
 - url: nftplus.io
-- url: "*.campus-party.org"
+- url: "brasil.campus-party.org"

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -1,33 +1,34 @@
 ---
-  - url: phantom.app
-    versionTag: "0.13.0"
-  - url: sneks.gg
-  - url: "*.web.app"
-  - url: "*.netlify.app"
-  - url: "*.growfastorganic.in"
-  - url: "*.notion.site"
-  - url: "*.amplifyapp.com"
-  - url: "*.slack.com"
-  - url: "*.medium.com"
-  - url: polygonventures.xyz
-  - url: "*.visit.express"
-  - url: "*.github.io"
-  - url: "*.ic0.app"
-  - url: "*.icp0.io"
-  - url: "*.4everland.io"
-  - url: "*.monstre.net"
-  - url: fatcatsupgrade.com
-  - url: idle-miner.club
-  - url: "*.spheron.app"
-  - url: "*.sphn.link"
-  - url: "*.vercel.app"
-  - url: "*.arweave.net"
-  - url: wenwencoin.com
-  - url: "*.glitch.me"
-  - url: "*.pages.dev"
-  - url: google.com
-  - url: "*.webflow.io"
-  - url: "*.tistory.com"
-  - url: "*.surge.sh"
-  - url: revoke.cash
-  - url: nftplus.io
+- url: phantom.app
+  versionTag: "0.13.0"
+- url: sneks.gg
+- url: "*.web.app"
+- url: "*.netlify.app"
+- url: "*.growfastorganic.in"
+- url: "*.notion.site"
+- url: "*.amplifyapp.com"
+- url: "*.slack.com"
+- url: "*.medium.com"
+- url: polygonventures.xyz
+- url: "*.visit.express"
+- url: "*.github.io"
+- url: "*.ic0.app"
+- url: "*.icp0.io"
+- url: "*.4everland.io"
+- url: "*.monstre.net"
+- url: fatcatsupgrade.com
+- url: idle-miner.club
+- url: "*.spheron.app"
+- url: "*.sphn.link"
+- url: "*.vercel.app"
+- url: "*.arweave.net"
+- url: wenwencoin.com
+- url: "*.glitch.me"
+- url: "*.pages.dev"
+- url: google.com
+- url: "*.webflow.io"
+- url: "*.tistory.com"
+- url: "*.surge.sh"
+- url: revoke.cash
+- url: nftplus.io
+- url: "*.campus-party.org"


### PR DESCRIPTION
Brazilian campus party page `brasil.campus-party.org`  is being blocked by phantom wallet. It's a organization page for the event, doesn't require any sort of wallet integration nor trigger it.

This PR whitelists it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added brasil.campus-party.org to the domain whitelist.
  * Reformatted the whitelist entries for consistency while preserving existing entries (including the phantom.app entry and its version).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phantom/blocklist/pull/1814)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->