### PR TITLE
Update whitelist.yaml (bitmixlist.org)

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,4 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: bitmixlist.org


### PR DESCRIPTION
I previously contacted Phantom support by email about a Phantom block/warning affecting this domain, and I was told the issue was fixed. The warning has now returned.

Domain:
https://bitmixlist.org

Issue:
Phantom is again blocking or warning users when visiting/interacting with the site.

Given that we do not provide any Web3 or Solana capabilities on our website, it doesn't make sense for the automated scanner to continue flagging it. As I understand this is probably a bug, I have made a patch that adds it to the whitelist so that the issue is resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated whitelist configuration entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->