### PR TITLE
Whitelist playpoom.com (false positive — legitimate on-chain game)

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -31,3 +31,5 @@
   - url: "*.surge.sh"
   - url: revoke.cash
   - url: nftplus.io
+  - url: playpoom.com
+  - url: "*.playpoom.com"


### PR DESCRIPTION
Requesting whitelist for playpoom.com — a provably-fair on-chain game on Solana
  (program 7DkARNBYPYtWRzhoY2abqbaAhXh96x69yQLJqAJ79nbB). It is currently shown as
  malicious by the real-time scanner — a false positive triggered by a new domain plus
  a bounded, revocable SPL Token Approve used for gasless/delegated play. The approval
  is limited to the player's chosen budget (not unlimited), the UI matches the on-chain
  action exactly, one-click Revoke is provided, and funds only move into the program's
  own game vaults — never to any operator wallet. Open Phantom support ticket: 224428.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the allowlist to include `playpoom.com` and its subdomains, expanding support for those sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->